### PR TITLE
refactor: load general config

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,4 @@
+{
+    "data_path": "data/RAW_recipes.csv"
+}
+  

--- a/src/webapp_mangetamain/load_config.py
+++ b/src/webapp_mangetamain/load_config.py
@@ -1,4 +1,26 @@
-"Load config and data from csv file"
-import pandas as pd 
+"""Load config from config.json"""
+import json
+import os
+import pandas as pd
 
-recipe = pd.read_csv("data/RAW_recipes.csv")
+class Config:
+    """Simple config loader that allows attribute-style access."""
+    def __init__(self, config_dict):
+        for key, value in config_dict.items():
+            if isinstance(value, dict):
+                value = Config(value)
+            setattr(self, key, value)
+
+    @classmethod
+    def from_json(cls, filepath):
+        """Load config from a JSON file."""
+        with open(filepath, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        return cls(data)
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "config.json")
+CONFIG_PATH = os.path.abspath(CONFIG_PATH)
+
+cfg = Config.from_json(CONFIG_PATH)
+
+recipe = pd.read_csv(cfg.data_path)


### PR DESCRIPTION
This MR improves the way configuration is loaded by removing hardcoded paths from the code.
Load config as cfg from config.json in /src