### PR TITLE
add Complexity analysis tab and visualization functions

### DIFF
--- a/src/webapp_mangetamain/filter_data.py
+++ b/src/webapp_mangetamain/filter_data.py
@@ -1,1 +1,25 @@
 """filter drinks and foods"""
+import pandas as pd
+import numpy as np
+import load_config
+
+
+recipes = load_config.recipe
+
+
+def general_complexity_prepocessing(df: pd.DataFrame):
+    df = df.copy()
+    
+    for c in ["minutes", "n_steps", "n_ingredients"]:
+        df = df[df[c] > 0]
+
+    for c in ["minutes", "n_steps", "n_ingredients"]:
+        q = df[c].quantile(0.99)
+        df = df[df[c] <= q]
+        
+        df["log_minutes"] = np.log1p(df["minutes"])
+
+    return df
+
+
+recipes_clean = general_complexity_prepocessing(recipes)

--- a/src/webapp_mangetamain/recipe_complexity.py
+++ b/src/webapp_mangetamain/recipe_complexity.py
@@ -1,0 +1,57 @@
+import pandas as pd
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+def make_univariate_figs(df: pd.DataFrame, feature: str, hue: str | None = None):
+    """
+    Retourne (hist_fig, box_fig) pour une feature.
+    """
+    data = df[feature]
+    # hist
+    hist_fig, ax = plt.subplots(figsize=(5, 3.5))
+    sns.histplot(data, bins=40, kde=True, ax=ax)
+    ax.set_title(f"Distribution of {feature}")
+    ax.set_xlabel(feature)
+    ax.set_ylabel("Count")
+    hist_fig.tight_layout()
+
+    # box
+    box_fig, ax2 = plt.subplots(figsize=(5, 3.5))
+    if hue and hue in data.columns:
+        sns.boxplot(data=data, x=hue, y=feature, ax=ax2)
+        ax2.set_title(f"{feature} by {hue}")
+        ax2.set_xlabel(hue)
+        ax2.set_ylabel(feature)
+    else:
+        sns.boxplot(x=data, ax=ax2)
+        ax2.set_title(f"Boxplot of {feature}")
+        ax2.set_xlabel(feature)
+    box_fig.tight_layout()
+
+    return hist_fig, box_fig
+
+
+
+def make_pairplot_fig(df: pd.DataFrame, features: list[str], hue: str | None = None):
+    """Retourne la figure du pairplot."""
+    data = df[features]
+
+    g = sns.pairplot(
+        data,
+        vars=features,
+        diag_kind="kde",
+        hue=(hue if hue and hue in data.columns else None),
+        corner=True,
+        plot_kws=dict(alpha=0.5, s=15),
+    )
+    return g.figure
+
+def make_corr_heatmap_fig(df: pd.DataFrame, features: list[str], title: str = "Correlation matrix"):
+    """Retourne la figure de la heatmap de corrélation."""
+    corr = df[features].corr()
+    fig, ax = plt.subplots(figsize=(5.5, 4.5))
+    sns.heatmap(corr, annot=True, fmt=".2f", cmap="coolwarm", vmin=-1, vmax=1, ax=ax)
+    ax.set_title(title)
+    fig.tight_layout()
+    return fig


### PR DESCRIPTION
 - Added `recipe_complexity.py` with modular plotting functions:
  - make_univariate_figs()
  - make_pairplot_fig()
  - make_corr_heatmap_fig()
- Implemented Streamlit tab `render_complexity_tab()`:
  - Univariate exploration with selectable feature (minutes, steps, ingredients)
  - Pairplot for feature relationships
  - Correlation matrix visualization
- Ensured compatibility with existing preprocessing and `kind` hue when available
- Prepared clean integration with preprocessed dataset (recipes_clean)