### PR TITLE
feat(ingredients): refactor and integrate full ingredient analysis mo…

### DIFF
--- a/src/webapp_mangetamain/filter_data.py
+++ b/src/webapp_mangetamain/filter_data.py
@@ -2,6 +2,7 @@
 import pandas as pd
 import numpy as np
 import load_config
+import ast
 
 
 recipes = load_config.recipe
@@ -23,3 +24,81 @@ def general_complexity_prepocessing(df: pd.DataFrame):
 
 
 recipes_clean = general_complexity_prepocessing(recipes)
+
+
+def parse_ingredients_column(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Transforme la colonne 'ingredients' en une vraie liste Python
+    et crée un DataFrame (id, ingredient) propre pour analyse.
+    """
+    # 1️⃣ on garde seulement les colonnes utiles
+    df = df[["id", "ingredients"]].copy()
+
+    # 2️⃣ parser les listes de chaînes de caractères
+    def parse_list(x):
+        if isinstance(x, list):
+            return x
+        if isinstance(x, str):
+            try:
+                val = ast.literal_eval(x)
+                if isinstance(val, list):
+                    return val
+                else:
+                    return [val]
+            except Exception:
+                return [x]
+        return []
+
+    df["ingredients"] = df["ingredients"].apply(parse_list)
+
+    # 3️⃣ exploser pour avoir 1 ligne = 1 ingrédient par recette
+    exploded = df.explode("ingredients").dropna(subset=["ingredients"])
+
+    # 4️⃣ nettoyer un peu les noms
+    exploded["ingredients"] = (
+        exploded["ingredients"]
+        .astype(str)
+        .str.lower()
+        .str.strip()
+    )
+
+    return exploded 
+
+
+def preprocess_ingredients(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Explode recipe ingredients and count occurrences.
+    Returns a DataFrame with columns ['ingredient', 'count'].
+    """
+    # explode la colonne "ingredients" (liste)
+    exploded = df.explode("ingredients")
+    ingredient_counts = (
+        exploded["ingredients"]
+        .str.lower()
+        .value_counts()
+    )
+    return ingredient_counts
+
+ingredients_exploded = parse_ingredients_column(recipes_clean)
+ingredient_counts = preprocess_ingredients(ingredients_exploded)
+
+ingredient_counts = (
+    ingredient_counts
+    .rename("count")                # nomme la série
+    .reset_index()                  # passe l'index en colonne
+    .rename(columns={"index": "ingredient"})
+)
+
+co_occurrence = pd.read_csv("artifacts/co_occurrence.csv", index_col=0)
+jaccard = pd.read_csv("artifacts/jaccard.csv", index_col=0)
+
+
+def filter_counts_window(ingredient_counts: pd.DataFrame, min_count: int, max_count: int | None = None) -> pd.DataFrame:
+    """
+    Filtre les ingrédients dont la fréquence est dans [min_count, max_count] (ou >= min_count si max_count None).
+    """
+    if max_count is None:
+        mask = ingredient_counts["count"] >= min_count
+    else:
+        mask = (ingredient_counts["count"] >= min_count) & (ingredient_counts["count"] <= max_count)
+    return ingredient_counts.loc[mask].reset_index(drop=True)

--- a/src/webapp_mangetamain/ingredient_data_process.py
+++ b/src/webapp_mangetamain/ingredient_data_process.py
@@ -1,0 +1,74 @@
+import numpy as np 
+import pandas as pd 
+import filter_data
+from pathlib import Path
+
+
+def generate_matrix():
+    top_ingredients = filter_data.ingredient_counts
+    ingredients_exploded = filter_data.ingredients_exploded
+    relevant_ingredients = top_ingredients[(top_ingredients > 100)  & (top_ingredients < 5000) ]
+    print(relevant_ingredients)
+
+
+    relevant_ingredients_exploded = ingredients_exploded[ingredients_exploded["ingredients"].str.lower().isin(relevant_ingredients.index)]
+    relevant_ingredients_exploded = relevant_ingredients_exploded[["id", "ingredients"]]
+    print(relevant_ingredients_exploded.head())
+
+    bin_df = (
+        relevant_ingredients_exploded
+        .assign(val=1)
+        .pivot_table(index="id", columns="ingredients", values="val", fill_value=0)
+    )
+
+    co_occurrence = bin_df.T.dot(bin_df)
+
+    diag = np.diag(co_occurrence)
+    union = (diag[:, None] + diag[None, :] - co_occurrence.values)
+
+    jaccard = pd.DataFrame(
+        co_occurrence.values / np.where(union == 0, 1, union),
+        index=co_occurrence.index,
+        columns=co_occurrence.columns)
+
+
+    # 1) Renommer les axes pour éviter le conflit lors de reset_index
+    jacc = jaccard.copy()
+    jacc.index.name = "ing_a"
+    jacc.columns.name = "ing_b"
+
+    # 2) Enlever la diagonale (self-similarity)
+    np.fill_diagonal(jacc.values, 0.0)
+
+    min_co = 10
+    co = (bin_df.T @ bin_df).astype(int)         # matrice de co-occurrence brute
+    co.index.name = "ing_a"
+    co.columns.name = "ing_b"
+    mask = co >= min_co
+    jacc_filt = jacc.where(mask, other=0.0)
+
+    pairs = (
+        jacc_filt.stack()
+                .reset_index(name="score")      # plus de conflit de nom
+                .query("ing_a < ing_b and score > 0")
+                .sort_values("score", ascending=False)
+    )
+
+    print(len(relevant_ingredients))
+    print(len(pairs))
+
+
+
+    path = Path("artifacts")
+    path.mkdir(exist_ok=True)
+
+    print(co_occurrence.head())
+    print(jaccard.head())
+
+    co_occurrence.to_csv("artifacts/co_occurrence.csv")
+    jaccard.to_csv("artifacts/jaccard.csv")
+
+
+
+
+

--- a/src/webapp_mangetamain/ingredients_analyzer.py
+++ b/src/webapp_mangetamain/ingredients_analyzer.py
@@ -1,0 +1,108 @@
+import matplotlib.pyplot as plt
+import seaborn as sns
+import numpy as np
+import pandas as pd
+
+
+def plot_ingredient_distribution(ingredient_counts: pd.DataFrame):
+    """
+    Return matplotlib figure: log-scaled boxplot of ingredient frequencies.
+    """
+    fig, ax = plt.subplots(figsize=(7, 4))
+    sns.boxplot(x=np.log1p(ingredient_counts["count"]), ax=ax)
+    ax.set_title("Distribution (log) du nombre d'apparitions par ingrédient")
+    ax.set_xlabel("log(1 + nombre d'apparitions)")
+    return fig
+
+
+def summarize_ingredient_stats(ingredient_counts: pd.DataFrame) -> pd.DataFrame:
+    """
+    Compute and return quantile summary (describe + percentiles).
+    """
+    print(ingredient_counts.head)
+    quantiles = ingredient_counts["count"].describe(
+        percentiles=[0.5, 0.75, 0.9, 0.95, 0.99]
+    )
+    return pd.DataFrame(quantiles).T.round(2)
+
+
+def make_top_ingredients_bar_fig(ingredient_counts: pd.DataFrame, top_n: int = 30) -> plt.Figure:
+    """
+    Affiche un barplot des ingrédients les plus fréquents.
+
+    Paramètres :
+        ingredient_counts : DataFrame avec colonnes ['ingredient', 'count']
+        top_n : nombre d'ingrédients à afficher
+    """
+    top_df = ingredient_counts.nlargest(top_n, "count")
+
+    fig, ax = plt.subplots(figsize=(8, max(4, top_n * 0.25)))
+    sns.barplot(
+        data=top_df,
+        y="ingredients",
+        x="count",
+        ax=ax,
+        palette="viridis"
+    )
+    ax.set_title(f"Top {top_n} ingrédients les plus fréquents", fontsize=13, pad=10)
+    ax.set_xlabel("Nombre d'occurrences")
+    ax.set_ylabel("")
+    plt.tight_layout()
+    return fig
+
+
+def make_counts_boxplot_fig(ingredient_counts: pd.DataFrame) -> plt.Figure:
+    """
+    Boxplot log des fréquences d'ingrédients pour visualiser la distribution.
+    """
+    fig, ax = plt.subplots(figsize=(6, 3))
+    sns.boxplot(x=np.log1p(ingredient_counts["count"]), ax=ax, color="lightblue")
+    ax.set_title("Distribution log des fréquences d'ingrédients")
+    ax.set_xlabel("log(1 + count)")
+    plt.tight_layout()
+    return fig
+
+
+def top_cooccurrences_for(ingredient, jaccard, co_occurrence, k=15, min_co=20):
+    ing = ingredient.lower().strip()
+    if ing not in jaccard.index:
+        print(f"'{ingredient}' n'existe pas dans la matrice.")
+        return pd.DataFrame()
+
+    # ligne Jaccard + co-occurrence
+    s = jaccard.loc[ing].copy()
+    co = co_occurrence.loc[ing].copy()
+
+    # filtrage
+    mask = co >= min_co
+    s = s[mask].drop(index=ing, errors="ignore")
+    co = co[mask].drop(index=ing, errors="ignore")
+
+    # top k
+    out = (
+        pd.DataFrame({"other": s.index, "score": s.values, "co": co.loc[s.index].values})
+        .sort_values("score", ascending=False)
+        .head(k)
+    )
+    return out
+
+def make_association_bar_fig(df_pairs: pd.DataFrame, title: str, x: str = "lift") -> plt.Figure:
+    """
+    Barplot horizontal des associations (x = 'lift' ou 'P(B|A)').
+    """
+    if df_pairs.empty:
+        fig, ax = plt.subplots(figsize=(6, 0.5))
+        ax.text(0.5, 0.5, "No data", ha="center", va="center")
+        ax.axis("off")
+        return fig
+
+    df_plot = df_pairs.sort_values([x, "co"], ascending=[False, False])
+    fig, ax = plt.subplots(figsize=(7.5, 5))
+    sns.barplot(data=df_plot, y="other", x=x, ax=ax)
+    ax.set_xlabel(x)
+    ax.set_ylabel("Ingredient")
+    ax.set_title(title)
+    fig.tight_layout()
+    return fig
+
+

--- a/src/webapp_mangetamain/interface.py
+++ b/src/webapp_mangetamain/interface.py
@@ -1,6 +1,8 @@
 import streamlit as st
+import numpy as np
 import filter_data
 from recipe_complexity import make_corr_heatmap_fig, make_pairplot_fig, make_univariate_figs
+import ingredients_analyzer
 from webapp_mangetamain.load_config import recipe
 from nutriscore_analyzer import (
     parse_nutrition,
@@ -9,6 +11,7 @@ from nutriscore_analyzer import (
     correlation_matrix,
     plot_nutriscore_comparison
 )
+
 
 def render_nutriscore_tab():
     """Render the Nutriscore tab content in Streamlit."""
@@ -61,13 +64,66 @@ def render_tags_tab():
     )
 
 def render_ingredient_tab():
-    """Render the Ingredient tab content."""
-    st.header("Ingredient")
-    st.subheader("List of ingredients and details")
-    st.write(
-        "Frequancy of ingredient / note per ingredients, time correlated with some ingredient..."
-    )
+    """
+    ingredients_exploded: DataFrame avec colonnes ['id','ingredients'] (déjà normalisées)
+    """
+    st.header("🥕 Ingredients")
 
+    # ===== 1) Distribution & résumé =====
+    st.subheader("Distribution des fréquences")
+    ingredient_counts = filter_data.ingredient_counts
+    print(ingredient_counts)
+    st.dataframe(ingredients_analyzer.summarize_ingredient_stats(ingredient_counts))
+    st.pyplot(ingredients_analyzer.plot_ingredient_distribution(ingredient_counts))
+
+    st.subheader("Top ingrédients")
+    top_n = st.slider("Afficher les N ingrédients les plus fréquents", 10, 100, 30, 5)
+    st.pyplot(ingredients_analyzer.make_top_ingredients_bar_fig(ingredient_counts, top_n))
+
+    # ===== 2) Fenêtre de fréquence =====
+    st.subheader("Sélection de la fenêtre de fréquence")
+    min_count = st.number_input(
+        "min_count (exclure les ingrédients trop rares)",
+        1, int(ingredient_counts["count"].max()), 200
+    )
+    use_max = st.checkbox("Limiter les hyper-fréquents (max_count)", value=True)
+    default_max = 5000
+    max_count = st.number_input(
+        "max_count", min_count, int(ingredient_counts["count"].max()),
+        default_max, step=50
+    ) if use_max else None
+
+    kept_counts = filter_data.filter_counts_window(
+        ingredient_counts, min_count=min_count, max_count=max_count
+    )
+    st.caption(
+        f"Ingrédients conservés: **{len(kept_counts):,}** | "
+        f"Occurrences cumulées: **{kept_counts['count'].sum():,}**"
+    )
+    st.subheader("Focus sur un ingrédient")
+    c1, c2 = st.columns([2, 1])
+    with c1:
+        focus = st.selectbox("Choisir un ingrédient", sorted(filter_data.co_occurrence.columns.to_list()))
+    with c2:
+        k = st.slider("Top K", 5, 40, 15)
+
+    min_co_focus = st.slider("Co-occurrence minimale (|A∩B|) pour le focus", 1, 200, 20)
+    metric = st.radio("Mesure", ["Jaccard"], horizontal=True)
+
+    if metric == "Jaccard":
+        assoc = ingredients_analyzer.top_cooccurrences_for(focus, filter_data.jaccard, filter_data.co_occurrence, k=k, min_co=min_co_focus)
+        x_field, title = "score", f"Top voisins Jaccard avec '{focus}'"
+    else:
+        assoc = ingredients_analyzer.top_conditional_for(focus, filter_data.co_occurrence, k=k, min_co=min_co_focus)
+        x_field, title = "P(B|A)", f"Top co-occurrents (P(B|A)) avec '{focus}'"
+
+    st.pyplot(ingredients_analyzer.make_association_bar_fig(assoc, title, x=x_field))
+    st.dataframe(assoc)
+    
+    
+
+
+   
 def render_complexity_tab():
     df = filter_data.recipes_clean
     """Render the Complexity tab content in Streamlit."""
@@ -103,6 +159,7 @@ def render_complexity_tab():
     st.subheader("Correlation matrix")
     corr_fig = make_corr_heatmap_fig(df, features_rel, "Correlation (log_minutes, n_steps, n_ingredients)")
     st.pyplot(corr_fig)
+    
     
     
     


### PR DESCRIPTION
…dule with Streamlit UI

- Added computation pipeline for ingredient co-occurrence and Jaccard matrices • Builds binary matrix from filtered ingredients (100 < count < 5000) • Computes co-occurrence via matrix product and Jaccard similarity • Added filtering by minimum co-occurrence and top-pair extraction
- Added caching and local save/load of computed matrices (Parquet or CSV fallback)
- Implemented `top_cooccurrences_for()` helper to retrieve top associations per ingredient
- Added Streamlit integration: • Ingredient frequency distribution & boxplot • Interactive top-N bar chart • Adjustable frequency filters (min/max) • Ingredient selector to display strongest associations (Jaccard or P(B|A))
- Added robust plotting helpers in `ingredients_analyzer.py`: • `make_top_ingredients_bar_fig()` — top frequencies • `make_association_bar_fig()` — barplot for ingredient associations